### PR TITLE
Reduce unsafe usage

### DIFF
--- a/src/hardware/simulation.rs
+++ b/src/hardware/simulation.rs
@@ -10,9 +10,6 @@ pub struct SimulationIsoTpChannel {
     rx_queue: Arc<RwLock<VecDeque<Vec<u8>>>>,
 }
 
-unsafe impl Send for SimulationIsoTpChannel{}
-unsafe impl Sync for SimulationIsoTpChannel{}
-
 impl SimulationIsoTpChannel {
     pub fn new() -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,6 @@ pub enum ServerEvent<'a, SessionState> {
     InterfaceCloseOnExitError(ChannelError),
 }
 
-unsafe impl<'a, SessionType> Send for ServerEvent<'a, SessionType> {}
-unsafe impl<'a, SessionType> Sync for ServerEvent<'a, SessionType> {}
-
 /// Handler for when [ServerEvent] get broadcast by the diagnostic servers background thread
 pub trait ServerEventHandler<SessionState>: Send + Sync {
     /// Handle incoming server events

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -80,7 +80,10 @@ impl<'a> Service09<'a> {
         let resp = self
             .server
             .exec_command(OBD2Cmd::new(OBD2Command::Service09, &[0x02]))?;
-        Ok(unsafe { String::from_utf8_unchecked(resp[3..].to_vec()) })
+        Ok(
+            String::from_utf8_lossy(resp.get(3..).ok_or(DiagError::InvalidResponseLength)?)
+                .into_owned(),
+        )
     }
 
     /// Reads the vehicles stored calibration ID (More than 1 may be returned)

--- a/src/uds/mod.rs
+++ b/src/uds/mod.rs
@@ -662,9 +662,6 @@ pub fn get_description_of_ecu_error(error: u8) -> UDSError {
     error.into()
 }
 
-unsafe impl Sync for UdsDiagnosticServer {}
-unsafe impl Send for UdsDiagnosticServer {}
-
 impl Drop for UdsDiagnosticServer {
     fn drop(&mut self) {
         self.server_running.store(false, Ordering::Relaxed); // Stop server


### PR DESCRIPTION
This will need a minor version bump (0.90 -> 0.91) because it removes some impls, which allow for triggering undefined behavior.