### PR TITLE
Add global bus session control for KWP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecu_diagnostics"
-version = "0.90.32"
+version = "0.90.33"
 authors = ["Ashcon Mohseninia <ashconm@outlook.com>"]
 edition = "2021"
 description = "A rust crate for ECU diagnostic servers and communication APIs"

--- a/src/dynamic_diag.rs
+++ b/src/dynamic_diag.rs
@@ -66,6 +66,7 @@ impl DynamicDiagSession {
                 global_tp_id: 0x00,
                 tester_present_interval_ms: 2000,
                 tester_present_require_response: true,
+                global_session_control: false
             },
             iso_tp_channel,
             channel_cfg,

--- a/src/kwp2000/read_ecu_identification.rs
+++ b/src/kwp2000/read_ecu_identification.rs
@@ -219,9 +219,7 @@ fn decode_block_ident(res: &mut Vec<u8>) -> DiagServerResult<SoftwareBlockIdenti
 
 impl Kwp2000DiagnosticServer {
     /// Reads Daimler ECU identification from ECU
-    pub fn read_daimler_identification(
-        &mut self,
-    ) -> DiagServerResult<DaimlerEcuIdent> {
+    pub fn read_daimler_identification(&mut self) -> DiagServerResult<DaimlerEcuIdent> {
         let res =
             self.execute_command_with_response(KWP2000Command::ReadECUIdentification, &[0x86])?;
         if res.len() != 18 {
@@ -242,9 +240,7 @@ impl Kwp2000DiagnosticServer {
     }
 
     /// Reads Daimler and MMC ECU identification from ECU
-    pub fn read_daimler_mmc_identification(
-        &mut self,
-    ) -> DiagServerResult<DaimlerMmcEcuIdent> {
+    pub fn read_daimler_mmc_identification(&mut self) -> DiagServerResult<DaimlerMmcEcuIdent> {
         let res =
             self.execute_command_with_response(KWP2000Command::ReadECUIdentification, &[0x87])?;
         if res.len() != 22 {


### PR DESCRIPTION
On some older cars that utilize KWP, the ECU will never respond to session control operations, instead, it is required
that the tester sends session control on the global bus can ID, which puts EVERY ECU on the network into the specified session mode