### PR TITLE
Feature gate hardware implementations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Build No Features
+      run: cargo build --verbose --no-default-features
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,25 @@ members = [
     "ffi",
 ]
 
+[features]
+default = ["passthru", "socketcan"]
+socketcan = ["dep:socketcan-isotp", "dep:socketcan"]
+passthru = ["dep:libloading", "dep:shellexpand", "dep:winreg", "dep:serde_json", "dep:j2534_rust"]
+
+
 [dependencies]
-j2534_rust = "1.0"
-serde_json = "1.0.79"
-libloading = "0.7.3"
+j2534_rust = { version = "1.0", optional = true }
+serde_json = { version = "1.0.79", optional = true }
+libloading = { version = "0.7.3", optional = true }
 env_logger="0.9.0"
 log="0.4.16"
 strum = "0.24"
 strum_macros = "0.24"
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.10.1"
+winreg = { version = "0.10.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-shellexpand = "2.1.0"
-socketcan-isotp = "1.0.0"
-socketcan = "1.7.0"
+shellexpand = { version = "2.1.0", optional = true }
+socketcan-isotp = { version = "1.0.0", optional = true }
+socketcan = { version = "1.7.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ passthru = ["dep:libloading", "dep:shellexpand", "dep:winreg", "dep:serde_json",
 j2534_rust = { version = "1.0", optional = true }
 serde_json = { version = "1.0.79", optional = true }
 libloading = { version = "0.7.3", optional = true }
-env_logger="0.9.0"
 log="0.4.16"
 strum = "0.24"
 strum_macros = "0.24"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -6,7 +6,7 @@
 
 use std::{
     borrow::BorrowMut,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, PoisonError},
 };
 
 use crate::hardware::HardwareError;
@@ -54,6 +54,21 @@ impl std::fmt::Display for ChannelError {
             ChannelError::ConfigurationError => {
                 write!(f, "Channel opened prior to being configured")
             }
+        }
+    }
+}
+
+impl<T> From<PoisonError<T>> for ChannelError {
+    fn from(err: PoisonError<T>) -> Self {
+        ChannelError::HardwareError(HardwareError::from(err))
+    }
+}
+
+impl<T> From<PoisonError<T>> for HardwareError {
+    fn from(_x: PoisonError<T>) -> Self {
+        HardwareError::APIError {
+            code: 99,
+            desc: "PoisonError".into(),
         }
     }
 }

--- a/src/hardware/passthru/mod.rs
+++ b/src/hardware/passthru/mod.rs
@@ -19,7 +19,7 @@
 
 use std::{
     ffi::c_void,
-    sync::{Arc, Mutex, PoisonError},
+    sync::{Arc, Mutex},
     time::Instant,
 };
 
@@ -845,24 +845,6 @@ impl From<PassthruError> for HardwareError {
         HardwareError::APIError {
             code: err as u32,
             desc: err.to_string().into(),
-        }
-    }
-}
-
-impl<T> From<PoisonError<T>> for ChannelError {
-    fn from(_x: PoisonError<T>) -> Self {
-        ChannelError::HardwareError(HardwareError::APIError {
-            code: 99,
-            desc: "PoisonError".into(),
-        })
-    }
-}
-
-impl<T> From<PoisonError<T>> for HardwareError {
-    fn from(_x: PoisonError<T>) -> Self {
-        HardwareError::APIError {
-            code: 99,
-            desc: "PoisonError".into(),
         }
     }
 }


### PR DESCRIPTION
👋  Hey,

I'm trying to use this crate on a embedded device, and we don't have support for `libloading`.

This PR hides the hardware implementations behind feature flags so that they can be enabled conditionally.

Additionally it removes the `env_logger` dependency, but that's just because its not used anywhere in the project.