### PR TITLE
Software ISOTP channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecu_diagnostics"
-version = "0.90.43"
+version = "0.90.50-sw-isotp-beta"
 authors = ["Ashcon Mohseninia <ashconm@outlook.com>"]
 edition = "2021"
 description = "A rust crate for ECU diagnostic servers and communication APIs"

--- a/examples/passthru_isotp/src/main.rs
+++ b/examples/passthru_isotp/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
     let iso_tp_settings = IsoTPSettings {
         block_size: 8,
         st_min: 20,
-        extended_addressing: true,
+        extended_addresses: None,
         pad_frame: true,
         can_speed: 500000,
         can_use_ext_addr: false,

--- a/examples/uds_over_socketcan/src/main.rs
+++ b/examples/uds_over_socketcan/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
     let isotp_cfg = IsoTPSettings {
         block_size: 8,
         st_min: 20,
-        extended_addressing: false,
+        extended_addresses: None,
         pad_frame: true,
         can_speed: 500000,
         can_use_ext_addr: false,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,6 +37,8 @@ pub enum ChannelError {
     NotOpen,
     /// Channel not configured prior to opening
     ConfigurationError,
+    /// Other Channel error
+    Other(String)
 }
 
 impl std::fmt::Display for ChannelError {
@@ -51,6 +53,7 @@ impl std::fmt::Display for ChannelError {
             ChannelError::InterfaceNotOpen => write!(f, "channel's interface is not open"),
             ChannelError::HardwareError(err) => write!(f, "Channel hardware error: {}", err),
             ChannelError::NotOpen => write!(f, "Channel has not been opened"),
+            ChannelError::Other(e) => write!(f, "{}", e),
             ChannelError::ConfigurationError => {
                 write!(f, "Channel opened prior to being configured")
             }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -91,6 +91,12 @@ impl From<mpsc::RecvError> for ChannelError {
     }
 }
 
+impl From<mpsc::RecvTimeoutError> for ChannelError {
+    fn from(err: mpsc::RecvTimeoutError) -> Self {
+        ChannelError::WriteTimeout // Only used for writing
+    }
+}
+
 impl<T> From<mpsc::SendError<T>> for HardwareError {
     fn from(e: mpsc::SendError<T>) -> Self {
         HardwareError::APIError { 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -476,8 +476,9 @@ pub struct IsoTPSettings {
     ///
     /// NOTE: This value might be overridden by the device's implementation of ISO-TP
     pub st_min: u8,
-    /// Use extended ISO-TP addressing
-    pub extended_addressing: bool,
+    /// Extended addressing bytes
+    /// order is Tx ext address, Rx ext address
+    pub extended_addresses: Option<(u8, u8)>,
     /// Pad frames over ISO-TP if data size is less than 8.
     pub pad_frame: bool,
     /// Baud rate of the CAN Network
@@ -491,7 +492,7 @@ impl Default for IsoTPSettings {
         Self {
             block_size: 8,
             st_min: 20,
-            extended_addressing: false,
+            extended_addresses: None,
             pad_frame: true,
             can_speed: 500_000,
             can_use_ext_addr: false,

--- a/src/dynamic_diag.rs
+++ b/src/dynamic_diag.rs
@@ -2,7 +2,7 @@
 //!
 
 use std::{
-    borrow::BorrowMut,
+    borrow::{BorrowMut, Borrow},
     sync::{Arc, Mutex},
 };
 
@@ -219,6 +219,29 @@ impl DynamicDiagSession {
         match self.session.borrow_mut() {
             DynamicSessionType::Kwp(k) => k.send_byte_array(payload),
             DynamicSessionType::Uds(u) => u.send_byte_array(payload),
+        }
+    }
+
+    /// Sets read and write timeouts
+    pub fn set_rw_timeout(&mut self, read_timeout_ms: u32, write_timeout_ms: u32) {
+        match self.session.borrow_mut() {
+            DynamicSessionType::Kwp(k) => k.set_rw_timeout(read_timeout_ms, write_timeout_ms),
+            DynamicSessionType::Uds(u) => u.set_rw_timeout(read_timeout_ms, write_timeout_ms),
+        }
+    }
+
+    /// Get command response read timeout
+    pub fn get_read_timeout(&self) -> u32 {
+        match self.session.borrow() {
+            DynamicSessionType::Kwp(k) => k.get_read_timeout(),
+            DynamicSessionType::Uds(u) => u.get_read_timeout(),
+        }
+    }
+    /// Gets command write timeout
+    pub fn get_write_timeout(&self) -> u32 {
+        match self.session.borrow() {
+            DynamicSessionType::Kwp(k) => k.get_write_timeout(),
+            DynamicSessionType::Uds(u) => u.get_write_timeout(),
         }
     }
 }

--- a/src/hardware/passthru/lib_funcs.rs
+++ b/src/hardware/passthru/lib_funcs.rs
@@ -250,7 +250,7 @@ impl PassthruDrv {
         max_msgs: u32,
         timeout: u32,
     ) -> PassthruResult<Vec<PASSTHRU_MSG>> {
-        log::debug!("PT_READ_MSGS called. Channel ID: {}, {} msgs, Timeout {}", channel_id, max_msgs, timeout);
+        //log::debug!("PT_READ_MSGS called. Channel ID: {}, {} msgs, Timeout {}", channel_id, max_msgs, timeout);
         let mut msg_count: u32 = max_msgs;
         // Create a blank array of empty passthru messages according to the max we should read
         let mut write_array: Vec<PASSTHRU_MSG> = vec![

--- a/src/hardware/passthru/mod.rs
+++ b/src/hardware/passthru/mod.rs
@@ -267,6 +267,7 @@ pub struct PassthruDevice {
     device_idx: Option<u32>,
     can_channel: bool,
     isotp_channel: bool,
+    software_mode: bool
 }
 
 impl PassthruDevice {
@@ -282,6 +283,7 @@ impl PassthruDevice {
             device_idx: Some(idx),
             can_channel: false,
             isotp_channel: false,
+            software_mode: false
         };
         if let Ok(version) = ret.drv.get_version(idx) {
             // Set new version information from the device!
@@ -325,6 +327,25 @@ impl PassthruDevice {
             None => Err(HardwareError::DeviceNotOpen),
         }
     }
+
+    /// Toggles software channel emulation.
+    /// This is useful if you are trying to run a concurrent ISO-TP and CAN channel. As
+    /// the J2534 API does not support this (Confliting channels). Instead, the ISO-TP channel
+    /// will be emulated in software and the CAN packets are manually sent over an opened CAN channel.
+    ///
+    /// The CAN channel can then be accessed as normal, in parallel!
+    ///
+    /// ## CAUTION
+    /// Since this relys on a fully unfiltered CAN channel, some cheaper J2534 devices may struggle with
+    /// this mode, and result in unstable ISO-TP connections!
+    ///  
+    /// Note that this toggled state will only affect newly created channels, currently
+    /// opened channels will not be affected, so it would be best to close them prior to 
+    /// toggling this function
+    pub fn toggle_sw_channel(&mut self, state: bool) {
+        self.software_mode = state;
+    }
+
 }
 
 impl Drop for PassthruDevice {

--- a/src/hardware/passthru/sw_isotp.rs
+++ b/src/hardware/passthru/sw_isotp.rs
@@ -1,0 +1,221 @@
+use std::sync::mpsc;
+use std::time::Instant;
+
+use crate::channel::{PacketChannel, CanFrame, PayloadChannel, IsoTPSettings, ChannelError};
+
+use crate::hardware::*;
+
+use super::{PassthruDevice, PassthruCanChannel};
+
+#[derive(Debug, Clone)]
+enum ChannelMessage<T> {
+    ClearRx,
+    ClearTx,
+    SendData(T)
+}
+
+
+/// Passthru combination channel for software emulation of ISO-TP channel over CAN channel
+/// 
+/// ## Why?
+/// According to the J2534 API, a CAN and ISO-TP cannot be opened at the same time, as they both require
+/// physical access to the same hardware communication layer of the VCI.
+/// 
+/// To overcome this, we instead up open a dedicated CAN channel and run the ISO-TP communication via software.
+/// This allows for both CAN and ISO-TP to coexist at the same time.
+/// 
+/// ## IMPORTANT NOTE
+/// This mode is technically a violation of the J2534 API, whilst tested devices work fine with this
+/// some cheap 'clone' J2534 adapters may struggle with the high throughput CAN Channel that is requied for this
+/// to work.
+#[allow(missing_debug_implementations)]
+pub struct PtCombiChannel {
+    dev: Arc<Mutex<PassthruDevice>>,
+    iso_tp_cfg: Option<IsoTPSettings>,
+    can_cfg: Option<(u32, bool)>, // baud, extended
+    channel: PassthruCanChannel,
+
+    can_rx_queue: mpsc::Receiver<CanFrame>,
+    can_tx_queue: mpsc::Sender<ChannelMessage<CanFrame>>,
+
+    isotp_rx_queue: mpsc::Receiver<(u32, Vec<u8>)>,
+    isotp_tx_queue: mpsc::Sender<ChannelMessage<(u32, Vec<u8>)>>,
+
+}
+
+unsafe impl Sync for PtCombiChannel{}
+unsafe impl Send for PtCombiChannel{}
+
+impl PtCombiChannel {
+    /// Creates a new combi channel using a given passthru device
+    pub fn new(dev: Arc<Mutex<PassthruDevice>>) -> HardwareResult<Self> {
+        {
+            let mut this = dev.lock().unwrap();
+            if this.can_channel || this.isotp_channel {
+                // Cannot proceed as dedicated CAN or ISO-TP dedicated channel is already open
+                return Err(HardwareError::ConflictingChannel)
+            }
+            
+            // We now own both channel types. This prevents further access to these channels
+            this.can_channel = true;
+            this.isotp_channel = true;
+        }
+
+        let c = PassthruDevice::make_can_channel_raw(dev.clone())?;
+
+        let (tx_can_send, rx_can_send) = mpsc::channel::<ChannelMessage<CanFrame>>();
+        let (tx_can_recv, rx_can_recv) = mpsc::channel::<CanFrame>();
+
+        let (tx_isotp_send, rx_isotp_send) = mpsc::channel::<ChannelMessage<(u32, Vec<u8>)>>();
+        let (tx_isotp_recv, rx_isotp_recv) = mpsc::channel::<(u32, Vec<u8>)>();
+
+
+
+
+        Ok(Self {
+            dev,
+            iso_tp_cfg: None,
+            can_cfg: None,
+            channel: c,
+            can_rx_queue: rx_can_recv,
+            can_tx_queue: tx_can_send,
+
+            isotp_rx_queue: rx_isotp_recv,
+            isotp_tx_queue: tx_isotp_send
+        })
+    }
+}
+
+
+impl CanChannel for PtCombiChannel {
+    fn set_can_cfg(&mut self, baud: u32, use_extended: bool) -> crate::channel::ChannelResult<()> {
+        if let Some(icfg) = self.iso_tp_cfg {
+            if icfg.can_use_ext_addr != use_extended || icfg.can_speed != baud {
+                // Mismatched settings!
+                return Err(ChannelError::HardwareError(HardwareError::APIError { 
+                    code: 99, 
+                    desc: "CAN channel settings incompatible with open already active ISOTP settings".into()
+                }))
+            }
+        }
+        self.can_cfg = Some((baud, use_extended));
+        Ok(())
+    }
+}
+
+impl IsoTPChannel for PtCombiChannel {
+    fn set_iso_tp_cfg(&mut self, cfg: IsoTPSettings) -> crate::channel::ChannelResult<()> {
+        if let Some(ccfg) = self.can_cfg {
+            if ccfg.1 != cfg.can_use_ext_addr || ccfg.0 != cfg.can_speed {
+                // Mismatched settings!
+                return Err(ChannelError::HardwareError(HardwareError::APIError { 
+                    code: 99, 
+                    desc: "ISOTP channel settings incompatible with open already active CAN settings".into()
+                }))
+            }
+        }
+        self.iso_tp_cfg = Some(cfg);
+        Ok(())
+    }
+}
+
+impl PacketChannel<CanFrame> for PtCombiChannel {
+    fn open(&mut self) -> crate::channel::ChannelResult<()> {
+        if self.can_cfg.is_none() {
+            return Err(ChannelError::ConfigurationError)
+        }
+        // Can channel already open! So OK
+        Ok(())
+    }
+
+    fn close(&mut self) -> crate::channel::ChannelResult<()> {
+        self.can_cfg = None;
+        Ok(())
+    }
+
+    fn write_packets(&mut self, packets: Vec<CanFrame>, _timeout_ms: u32) -> crate::channel::ChannelResult<()> {
+        for p in packets {
+            self.can_tx_queue.send(ChannelMessage::SendData(p))?;
+        }
+        Ok(())
+    }
+
+    fn read_packets(&mut self, max: usize, timeout_ms: u32) -> crate::channel::ChannelResult<Vec<CanFrame>> {
+        let timeout = std::cmp::max(1, timeout_ms);
+        let mut res = vec![];
+        let instant = Instant::now();
+        while instant.elapsed().as_millis() <= timeout as u128 {
+            if let Ok(c) = self.can_rx_queue.try_recv() {
+                res.push(c)
+            }
+            if res.len() >= max {
+                break;
+            }
+        }
+        Ok(res)
+    }
+
+    fn clear_rx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+        while self.can_rx_queue.recv().is_ok(){}
+        Ok(())
+    }
+
+    fn clear_tx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+        Ok(self.can_tx_queue.send(ChannelMessage::ClearTx)?)
+    }
+}
+
+impl PayloadChannel for PtCombiChannel {
+    fn open(&mut self) -> crate::channel::ChannelResult<()> {
+        if self.iso_tp_cfg.is_none() {
+            return Err(ChannelError::ConfigurationError)
+        }
+        Ok(())
+    }
+
+    fn close(&mut self) -> crate::channel::ChannelResult<()> {
+        self.iso_tp_cfg = None;
+        self.dev.lock().unwrap().isotp_channel = false;
+        Ok(())
+    }
+
+    fn set_ids(&mut self, send: u32, recv: u32) -> crate::channel::ChannelResult<()> {
+        todo!()
+    }
+
+    fn read_bytes(&mut self, timeout_ms: u32) -> crate::channel::ChannelResult<Vec<u8>> {
+        let timeout = std::cmp::max(1, timeout_ms);
+        let instant = Instant::now();
+        while instant.elapsed().as_millis() <= timeout as u128 {
+            if let Ok(c) = self.isotp_rx_queue.try_recv() {
+                return Ok(c.1);
+            }
+        }
+        Err(ChannelError::BufferEmpty)
+    }
+
+    fn write_bytes(&mut self, addr: u32, buffer: &[u8], _timeout_ms: u32) -> crate::channel::ChannelResult<()> {
+        self.isotp_tx_queue.send(ChannelMessage::SendData((addr, buffer.to_vec())))?;
+        Ok(())
+    }
+
+    fn clear_rx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+        while self.isotp_rx_queue.recv().is_ok(){}
+        Ok(())
+    }
+
+    fn clear_tx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+        Ok(self.isotp_tx_queue.send(ChannelMessage::ClearTx)?)
+    }
+}
+
+impl Drop for PtCombiChannel {
+    fn drop(&mut self) {
+        self.channel.close();
+        {
+            let mut this = self.dev.lock().unwrap();
+            this.can_channel = false;
+            this.isotp_channel = false;
+        }
+    }
+}

--- a/src/hardware/passthru/sw_isotp.rs
+++ b/src/hardware/passthru/sw_isotp.rs
@@ -1,17 +1,25 @@
+use std::borrow::BorrowMut;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
-use std::time::Instant;
+use std::thread::JoinHandle;
+use std::time::{Instant, Duration};
+use std::vec;
 
-use crate::channel::{PacketChannel, CanFrame, PayloadChannel, IsoTPSettings, ChannelError};
+use crate::channel::{PacketChannel, CanFrame, PayloadChannel, IsoTPSettings, ChannelError, ChannelResult, Packet};
 
 use crate::hardware::*;
 
 use super::{PassthruDevice, PassthruCanChannel};
 
 #[derive(Debug, Clone)]
-enum ChannelMessage<T> {
+enum ChannelMessage<T, X> {
     ClearRx,
     ClearTx,
-    SendData(T)
+    SendData(T),
+    SetConfig(X),
+    SetFilter(u32, u32), // Only for ISOTP
+    Open,
+    Close
 }
 
 
@@ -30,29 +38,53 @@ enum ChannelMessage<T> {
 /// to work.
 #[allow(missing_debug_implementations)]
 pub struct PtCombiChannel {
-    dev: Arc<Mutex<PassthruDevice>>,
-    iso_tp_cfg: Option<IsoTPSettings>,
-    can_cfg: Option<(u32, bool)>, // baud, extended
-    channel: PassthruCanChannel,
-
     can_rx_queue: mpsc::Receiver<CanFrame>,
-    can_tx_queue: mpsc::Sender<ChannelMessage<CanFrame>>,
+    can_tx_queue: mpsc::Sender<ChannelMessage<CanFrame, (u32, bool)>>,
+    can_tx_res_queue: mpsc::Receiver<ChannelResult<()>>,
 
     isotp_rx_queue: mpsc::Receiver<(u32, Vec<u8>)>,
-    isotp_tx_queue: mpsc::Sender<ChannelMessage<(u32, Vec<u8>)>>,
+    isotp_tx_queue: mpsc::Sender<ChannelMessage<(u32, Vec<u8>), IsoTPSettings>>,
+    isotp_tx_res_queue: mpsc::Receiver<ChannelResult<()>>,
 
+    can_mutex: Mutex<()>,
+    isotp_mutex: Mutex<()>,
+    handle: Option<JoinHandle<()>>,
+    running: Arc<AtomicBool>
+}
+
+struct IsoTpPayload {
+    pub data: Vec<u8>,
+    pub curr_size: usize,
+    pub max_size: usize,
+    pub cts: bool,
+    pub pci: u8,
+    pub max_cpy_size: u8,
+    pub ext_addr: bool,
+    pub bs: u8,
+    pub stmin: u8,
 }
 
 unsafe impl Sync for PtCombiChannel{}
 unsafe impl Send for PtCombiChannel{}
 
+fn parse_packet<'a>(cf: &'a CanFrame, iso_tp_ext: bool) -> (u32, &'a[u8]) {
+    let data = cf.get_data();
+    match iso_tp_ext {
+        true => ((cf.get_address()) | data[0] as u32, &data[1..]),
+        false => (cf.get_address(), data)
+    }
+
+}
+
 impl PtCombiChannel {
     /// Creates a new combi channel using a given passthru device
     pub fn new(dev: Arc<Mutex<PassthruDevice>>) -> HardwareResult<Self> {
         {
+            log::debug!("SW Combi channel constructor called");
             let mut this = dev.lock().unwrap();
             if this.can_channel || this.isotp_channel {
                 // Cannot proceed as dedicated CAN or ISO-TP dedicated channel is already open
+                log::error!("CAN/ISO-TP dedicated channel already open");
                 return Err(HardwareError::ConflictingChannel)
             }
             
@@ -61,86 +93,423 @@ impl PtCombiChannel {
             this.isotp_channel = true;
         }
 
-        let c = PassthruDevice::make_can_channel_raw(dev.clone())?;
-
-        let (tx_can_send, rx_can_send) = mpsc::channel::<ChannelMessage<CanFrame>>();
+        let (tx_can_send, rx_can_send) = mpsc::channel::<ChannelMessage<CanFrame, (u32, bool)>>();
+        let (tx_can_send_res, rx_can_send_res) = mpsc::channel::<ChannelResult<()>>();
         let (tx_can_recv, rx_can_recv) = mpsc::channel::<CanFrame>();
 
-        let (tx_isotp_send, rx_isotp_send) = mpsc::channel::<ChannelMessage<(u32, Vec<u8>)>>();
+
+        let (tx_isotp_send, rx_isotp_send) = mpsc::channel::<ChannelMessage<(u32, Vec<u8>), IsoTPSettings>>();
+        let (tx_isotp_send_res, rx_isotp_send_res) = mpsc::channel::<ChannelResult<()>>();
         let (tx_isotp_recv, rx_isotp_recv) = mpsc::channel::<(u32, Vec<u8>)>();
 
+        let is_running = Arc::new(AtomicBool::new(true));
+        let is_running_t = is_running.clone();
 
+        let dev_handle = dev.clone();
+
+        let handle = std::thread::spawn(move|| {
+            let mut channel : Option<PassthruCanChannel> = None;
+            let mut iso_tp_cfg: Option<IsoTPSettings> = None;
+            let mut can_cfg: Option<(u32, bool)> = None;
+            let mut iso_tp_filter: Option<(u32, u32)> = None; // Tx, Rx
+            let mut isotp_rx: Option<IsoTpPayload> = None;
+            let mut isotp_tx: Option<IsoTpPayload> = None;
+            let mut ext_address = false;
+            let mut last_tx_time = Instant::now();
+            let mut tx_frames_sent = 0u32;
+            let mut rx_frames_received = 0u32;
+
+            log::info!("SW ISO-TP thread running!");
+            while is_running_t.load(Ordering::Relaxed) {
+                if let Ok(can_req) = rx_can_send.try_recv() {
+                    log::debug!("SW ISO-TP CAN Req: {:?}", can_req);
+                    tx_can_send_res.send(Ok(()));
+                }
+                if let Ok(isotp_req) = rx_isotp_send.try_recv() {
+                    let _send = match isotp_req {
+                        ChannelMessage::ClearRx => { 
+                            isotp_rx = None; 
+                            tx_isotp_send_res.send(Ok(())) 
+                        },
+                        ChannelMessage::ClearTx => { 
+                            isotp_tx = None; 
+                            tx_isotp_send_res.send(Ok(()))
+                        }, // Todo clear Tx buffer,
+                        ChannelMessage::SendData((addr, data)) => {
+                            if iso_tp_cfg.is_none() || iso_tp_filter.is_none() {
+                                tx_isotp_send_res.send(Err(ChannelError::ConfigurationError))
+                            } else if channel.is_none() {
+                                tx_isotp_send_res.send(Err(ChannelError::NotOpen))
+                            } else {
+                                let cfg = iso_tp_cfg.unwrap();
+                                let mut can = channel.as_mut().unwrap();
+                                // Send
+                                if (ext_address && data.len() < 6) || (!ext_address && data.len() < 7) {
+                                    let mut df: Vec<u8> = Vec::with_capacity(8);
+                                    if ext_address {
+                                        df.push(cfg.extended_addresses.unwrap().0);
+                                    }
+                                    df.push(data.len() as u8);
+                                    df.extend_from_slice(&data);
+                                    if cfg.pad_frame {
+                                        df.resize(8, 0xCC);
+                                    }
+                                    log::debug!("Sending ISO-TP msg as 1 CAN frame {:02X?}", df);
+                                    let cf = CanFrame::new(addr, &df, cfg.can_use_ext_addr);
+                                    tx_isotp_send_res.send(can.write_packets(vec![cf], 100))
+                                } else {
+                                    if isotp_tx.is_some() {
+                                        tx_isotp_send_res.send(Err(ChannelError::BufferFull))
+                                    } else if data.len() > 0xFFF {
+                                        tx_isotp_send_res.send(Err(ChannelError::UnsupportedRequest)) // Request too big
+                                    } else {
+                                        let mut df: Vec<u8> = Vec::with_capacity(8);
+                                        if ext_address {
+                                            df.push(cfg.extended_addresses.unwrap().0);
+                                        }
+                                        df.push((0x10 | ((data.len() as u32) >> 8) & 0x0F) as u8);
+                                        df.push(data.len() as u8);
+                                        let max_copy = if ext_address { 5 } else { 6 };
+                                        df.extend_from_slice(&data[0..max_copy]);
+                                        let cf = CanFrame::new(addr, &df, cfg.can_use_ext_addr);
+                                        let res = can.write_packets(vec![cf], 100);
+                                        if res.is_ok() {
+                                            isotp_tx = Some(IsoTpPayload {
+                                                data: data.clone(),
+                                                curr_size: max_copy,
+                                                max_size: data.len(),
+                                                cts: false,
+                                                pci: 0x21,
+                                                max_cpy_size: max_copy as u8+1,
+                                                ext_addr: ext_address,
+                                                // These 2 are temp, they are overriden by the ECU when FC comes in
+                                                bs: cfg.block_size,
+                                                stmin: cfg.st_min
+                                            });
+                                        }
+                                        tx_isotp_send_res.send(Ok(()))
+                                    }
+                                }
+                            }
+                        },
+                        ChannelMessage::SetConfig(cfg) => {
+                            let mut res: ChannelResult<()> = Ok(());
+                            if let Some(ccfg) = can_cfg {
+                                // Compare against CAN config
+                                if ccfg.0 != cfg.can_speed || ccfg.1 != cfg.can_use_ext_addr {
+                                    // Mismatched config!
+                                    res = Err(ChannelError::Other("CAN and ISO-TP cfg mismatched for combi channel".into()));
+                                }
+                            }
+                            if res.is_ok() {
+                                ext_address = cfg.extended_addresses.is_some();
+                                iso_tp_cfg = Some(cfg);
+                            }
+                            tx_isotp_send_res.send(res)
+                        },
+                        ChannelMessage::SetFilter(tx, rx) => {
+                            iso_tp_filter = Some((tx, rx));
+                            tx_isotp_send_res.send(Ok(()))
+                        },
+                        ChannelMessage::Open => {
+                            let mut res: ChannelResult<()> = Ok(());
+                            if iso_tp_cfg.is_none() {
+                                res = Err(ChannelError::ConfigurationError)
+                            }
+                            if channel.is_none() {
+                                // Try open channel
+                                match PassthruDevice::make_can_channel_raw(dev_handle.clone()) {
+                                    Ok(c) => { channel = Some(c) },
+                                    Err(e) => res = Err(e.into())
+                                };
+                                if let Some(can_channel) = channel.borrow_mut() {
+                                    let tp_cfg = iso_tp_cfg.unwrap();
+                                    res = can_channel.set_can_cfg(tp_cfg.can_speed, tp_cfg.can_use_ext_addr);
+                                    if res.is_ok() {
+                                        res = can_channel.open();
+                                    }
+                                }
+                            }
+                            tx_isotp_send_res.send(res)
+                        },
+                        ChannelMessage::Close => {
+                            iso_tp_cfg = None;
+                            isotp_rx = None;
+                            isotp_tx = None;
+                            tx_isotp_send_res.send(Ok(()))
+                        },
+                    };
+                }
+                let mut activity = false;
+                if let Some(c) = channel.borrow_mut() {
+                    let incomming = c.read_packets(100, 0).unwrap_or_default();
+                    if can_cfg.is_some() {
+                        for p in &incomming { tx_can_recv.send(*p); }
+                    }
+                    if let (Some(cfg), Some(filter)) = (iso_tp_cfg, iso_tp_filter)  {
+                        for packet in incomming {
+                            if packet.get_address() == filter.1 {
+                                if ext_address && packet.get_data()[1] != cfg.extended_addresses.unwrap().1 {
+                                    continue;
+                                }
+                                // IsoTP is some so process the incomming frame!
+                                // check PCI first (Quicker)
+                                let pci_idx = if ext_address {1} else {0};
+                                let pci_raw = *packet.get_data().get(pci_idx).unwrap_or(&0xFF);
+                                let pci = pci_raw & 0xF0;
+                                if pci == 0x00 || pci == 0x10 || pci == 0x20 || pci == 0x30 {
+                                    let data = packet.get_data();
+                                    log::debug!("Incomming ISO-TP frame 0x{:04X?}: {:02X?}", filter.1, data);
+                                    match pci {
+                                        0x00 => {
+                                            // Single frame
+                                            tx_isotp_recv.send((filter.1, data[1+pci_idx..1+pci_idx+pci_raw as usize].to_vec()));
+                                        },
+                                        0x10 => {
+                                            if isotp_rx.is_some() {
+                                                log::warn!("ISOTP Rx overwriting old payload!");
+                                            }
+                                            let size = ((data[pci_idx] as usize & 0x0F) << 8) | data[1+pci_idx] as usize;
+                                            let mut data_rx = Vec::with_capacity(size);
+                                            log::debug!("ISOTP Expecting data payload of {} bytes, sending FC", size);
+                                            data_rx.extend_from_slice(&data[pci_idx+2..]);
+                                            isotp_rx = Some(IsoTpPayload {
+                                                data: data_rx,
+                                                curr_size: 8-2-pci_idx,
+                                                max_size: size,
+                                                cts: true,
+                                                pci: 0x21,
+                                                max_cpy_size: if ext_address { 6 } else { 7 },
+                                                ext_addr: ext_address,
+                                                bs: cfg.block_size,
+                                                stmin: cfg.st_min,
+                                            });
+                                            // Send FC
+                                            let mut df: Vec<u8> = Vec::with_capacity(8);
+                                            if ext_address {
+                                                df.push(cfg.extended_addresses.unwrap().0);
+                                            }
+                                            df.extend_from_slice(&[0x30, cfg.block_size, cfg.st_min]);
+                                            if cfg.pad_frame {
+                                                df.resize(8, 0xCC);
+                                            }
+                                            if let Err(e) = c.write_packets(vec![CanFrame::new(filter.0, &df, cfg.can_use_ext_addr)], 100) {
+                                                isotp_rx = None; // Could not send FC
+                                                log::error!("Could not send FC to ECU: {}", e);
+                                            }
+                                            rx_frames_received = 0;
+                                        }
+                                        0x20 => {
+                                            if let Some(rx) = isotp_rx.borrow_mut() {
+                                                let mut max_copy = rx.max_size - rx.data.len();
+                                                if max_copy > rx.max_cpy_size as usize {
+                                                    max_copy = rx.max_cpy_size as usize;
+                                                }
+                                                rx_frames_received += 1;
+                                                rx.data.extend_from_slice(&data[1+pci_idx..1+pci_idx+max_copy]);
+                                                if rx.data.len() >= rx.max_size {
+                                                    // Yay, done!
+                                                    tx_isotp_recv.send((filter.1 ,rx.data.clone()));
+                                                    isotp_rx = None;
+                                                    continue;
+                                                }
+                                                // Not done, check if ECU requires a new FC msg
+                                                if rx.bs > 0 && rx_frames_received >= rx.bs as u32 {
+                                                    // Check for new fc required
+                                                    // Send FC
+                                                    let mut df: Vec<u8> = Vec::with_capacity(8);
+                                                    if ext_address {
+                                                        df.push(cfg.extended_addresses.unwrap().0);
+                                                    }
+                                                    df.extend_from_slice(&[0x30, cfg.block_size, cfg.st_min]);
+                                                    if cfg.pad_frame {
+                                                        df.resize(8, 0xCC);
+                                                    }
+                                                    if let Err(e) = c.write_packets(vec![CanFrame::new(filter.0, &df, cfg.can_use_ext_addr)], 100) {
+                                                        isotp_rx = None; // Could not send FC
+                                                        log::error!("Could not send FC to ECU: {}", e);
+                                                    }
+                                                    rx_frames_received = 0;
+                                                    // Send FC
+
+                                                }
+                                            }
+                                        }
+                                        0x30 => {
+                                            if pci_raw == 0x30 {
+                                                if let Some(to_tx) = isotp_tx.as_mut() {
+                                                    to_tx.cts = true;
+                                                    to_tx.bs = data[1+pci_idx];
+                                                    to_tx.stmin = data[2+pci_idx];
+                                                    if to_tx.stmin > 127 {
+                                                        to_tx.stmin = 1; // In microseconds, we don't count that fast, so use 1ms
+                                                    }
+                                                    last_tx_time = Instant::now();
+                                                    tx_frames_sent = 0;
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            log::warn!("Cannot handle ISO-TP frame {:02X?}", data);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        let mut send_complete = false;
+                        if let Some(tx_payload) = isotp_tx.borrow_mut() {
+                            // Handle Tx data
+                            let mut can_buffer = vec![];
+                            for _ in 0..8 { // 8 frames in a batch max - Makes Tx with 0bs faster
+                                if tx_payload.cts && ((last_tx_time.elapsed().as_millis() >= tx_payload.stmin.into()) || tx_payload.stmin == 0) {
+                                    let mut cf_payload = Vec::with_capacity(8);
+                                    // Do send
+                                    let max_copy = std::cmp::min(tx_payload.max_size-tx_payload.curr_size, tx_payload.max_cpy_size as usize);
+
+                                    if ext_address {
+                                        cf_payload.push(cfg.extended_addresses.unwrap().0)
+                                    }
+                                    cf_payload.push(tx_payload.pci);
+                                    cf_payload.extend_from_slice(&tx_payload.data[tx_payload.curr_size..tx_payload.curr_size+max_copy]);
+                                    can_buffer.push(CanFrame::new(filter.0, &cf_payload, cfg.can_use_ext_addr));
+                                    if cfg.pad_frame {
+                                        cf_payload.resize(8, 0xCC);
+                                    }
+
+                                    if tx_payload.bs != 0 { tx_frames_sent+=1; }
+                                    tx_payload.pci += 1;
+                                    tx_payload.curr_size += max_copy;
+                                    if tx_payload.pci == 0x30 {
+                                        tx_payload.pci = 0x20;
+                                    }
+
+                                    // Await new FC
+                                    last_tx_time = Instant::now();
+                                    if tx_frames_sent as u8 >= tx_payload.bs && tx_payload.bs != 0 {
+                                        tx_frames_sent = 0;
+                                        tx_payload.cts = false;
+                                        break;
+                                    }
+                                    if tx_payload.bs != 0 {
+                                        break; // Delay
+                                    }
+                                    if tx_payload.curr_size >= tx_payload.max_size {
+                                        send_complete = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if !can_buffer.is_empty() {
+                                if c.write_packets(can_buffer, 100).is_err() {
+                                    send_complete = true; // Destroy!
+                                }
+                            }
+                        }
+                        if send_complete {
+                            isotp_tx = None;
+                            log::debug!("ISO-TP Send completed!");
+                        }
+                    }
+                }
+
+                // Now decide how long to sleep for
+                if iso_tp_cfg.is_none() {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                } else {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            }
+            // Teardown
+            log::info!("SW ISO-TP closed");
+            if let Some(mut c) = channel.take() {
+                c.close();
+                let mut g = dev.lock().unwrap();
+                g.can_channel = false;
+                g.isotp_channel = false;
+            }
+        });
 
 
         Ok(Self {
-            dev,
-            iso_tp_cfg: None,
-            can_cfg: None,
-            channel: c,
             can_rx_queue: rx_can_recv,
             can_tx_queue: tx_can_send,
+            can_tx_res_queue: rx_can_send_res,
 
             isotp_rx_queue: rx_isotp_recv,
-            isotp_tx_queue: tx_isotp_send
+            isotp_tx_queue: tx_isotp_send,
+            isotp_tx_res_queue: rx_isotp_send_res,
+            can_mutex: Mutex::new(()),
+            isotp_mutex: Mutex::new(()),
+            running: is_running,
+            handle: Some(handle)
         })
     }
 }
 
 
 impl CanChannel for PtCombiChannel {
-    fn set_can_cfg(&mut self, baud: u32, use_extended: bool) -> crate::channel::ChannelResult<()> {
-        if let Some(icfg) = self.iso_tp_cfg {
-            if icfg.can_use_ext_addr != use_extended || icfg.can_speed != baud {
-                // Mismatched settings!
-                return Err(ChannelError::HardwareError(HardwareError::APIError { 
-                    code: 99, 
-                    desc: "CAN channel settings incompatible with open already active ISOTP settings".into()
-                }))
-            }
-        }
-        self.can_cfg = Some((baud, use_extended));
-        Ok(())
+    fn set_can_cfg(&mut self, baud: u32, use_extended: bool) -> ChannelResult<()> {
+        log::debug!("CAN SetCANCfg called");
+        let _guard = self.can_mutex.lock()?;
+        while self.can_tx_res_queue.try_recv().is_ok(){}
+        self.can_tx_queue.send(ChannelMessage::SetConfig((baud, use_extended)))?;
+        // Wait for channels response
+        self.can_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 }
 
 impl IsoTPChannel for PtCombiChannel {
-    fn set_iso_tp_cfg(&mut self, cfg: IsoTPSettings) -> crate::channel::ChannelResult<()> {
-        if let Some(ccfg) = self.can_cfg {
-            if ccfg.1 != cfg.can_use_ext_addr || ccfg.0 != cfg.can_speed {
-                // Mismatched settings!
-                return Err(ChannelError::HardwareError(HardwareError::APIError { 
-                    code: 99, 
-                    desc: "ISOTP channel settings incompatible with open already active CAN settings".into()
-                }))
-            }
-        }
-        self.iso_tp_cfg = Some(cfg);
-        Ok(())
+    fn set_iso_tp_cfg(&mut self, cfg: IsoTPSettings) -> ChannelResult<()> {
+        log::debug!("ISO-TP SetIsoTpCfg called");
+        let _guard = self.isotp_mutex.lock()?;
+        while self.isotp_tx_res_queue.try_recv().is_ok(){}
+        self.isotp_tx_queue.send(ChannelMessage::SetConfig(cfg))?;
+        // Wait for channels response
+        self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 }
 
 impl PacketChannel<CanFrame> for PtCombiChannel {
-    fn open(&mut self) -> crate::channel::ChannelResult<()> {
-        if self.can_cfg.is_none() {
-            return Err(ChannelError::ConfigurationError)
-        }
-        // Can channel already open! So OK
-        Ok(())
+    fn open(&mut self) -> ChannelResult<()> {
+        log::debug!("CAN Open called");
+        let _guard = self.can_mutex.lock()?;
+        while self.can_tx_res_queue.try_recv().is_ok(){}
+        self.can_tx_queue.send(ChannelMessage::Open)?;
+        // Wait for channels response
+        self.can_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 
-    fn close(&mut self) -> crate::channel::ChannelResult<()> {
-        self.can_cfg = None;
-        Ok(())
+    fn close(&mut self) -> ChannelResult<()> {
+        log::debug!("CAN Close called");
+        let _guard = self.can_mutex.lock()?;
+        while self.can_tx_res_queue.try_recv().is_ok(){}
+        self.can_tx_queue.send(ChannelMessage::Close)?;
+        // Wait for channels response
+        self.can_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 
-    fn write_packets(&mut self, packets: Vec<CanFrame>, _timeout_ms: u32) -> crate::channel::ChannelResult<()> {
+    fn write_packets(&mut self, packets: Vec<CanFrame>, timeout_ms: u32) -> ChannelResult<()> {
+        log::debug!("CAN WritePackets called");
+        let _guard = self.can_mutex.lock()?;
+        while self.can_tx_res_queue.try_recv().is_ok(){}
         for p in packets {
             self.can_tx_queue.send(ChannelMessage::SendData(p))?;
+            if timeout_ms != 0 {
+                match self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(timeout_ms as u64)) {
+                    Ok(m) => {
+                        if m.is_err() {
+                            return m
+                        }
+                    },
+                    Err(e) => return Err(e.into())
+                }
+            }
         }
         Ok(())
     }
 
-    fn read_packets(&mut self, max: usize, timeout_ms: u32) -> crate::channel::ChannelResult<Vec<CanFrame>> {
+    fn read_packets(&mut self, max: usize, timeout_ms: u32) -> ChannelResult<Vec<CanFrame>> {
+        log::debug!("CAN ReadPackets called");
         let timeout = std::cmp::max(1, timeout_ms);
         let mut res = vec![];
         let instant = Instant::now();
@@ -155,35 +524,48 @@ impl PacketChannel<CanFrame> for PtCombiChannel {
         Ok(res)
     }
 
-    fn clear_rx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
-        while self.can_rx_queue.recv().is_ok(){}
+    fn clear_rx_buffer(&mut self) -> ChannelResult<()> {
+        log::debug!("CAN ClearRxBuffer called");
+        while self.can_rx_queue.try_recv().is_ok(){}
         Ok(())
     }
 
-    fn clear_tx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+    fn clear_tx_buffer(&mut self) -> ChannelResult<()> {
+        log::debug!("CAN ClearTxBuffer called");
         Ok(self.can_tx_queue.send(ChannelMessage::ClearTx)?)
     }
 }
 
 impl PayloadChannel for PtCombiChannel {
-    fn open(&mut self) -> crate::channel::ChannelResult<()> {
-        if self.iso_tp_cfg.is_none() {
-            return Err(ChannelError::ConfigurationError)
-        }
-        Ok(())
+    fn open(&mut self) -> ChannelResult<()> {
+        log::debug!("ISO-TP Open called");
+        let _guard = self.isotp_mutex.lock()?;
+        while self.isotp_tx_res_queue.try_recv().is_ok(){}
+        self.isotp_tx_queue.send(ChannelMessage::Open)?;
+        // Wait for channels response
+        self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 
-    fn close(&mut self) -> crate::channel::ChannelResult<()> {
-        self.iso_tp_cfg = None;
-        self.dev.lock().unwrap().isotp_channel = false;
-        Ok(())
+    fn close(&mut self) -> ChannelResult<()> {
+        log::debug!("ISO-TP Close called");
+        let _guard = self.isotp_mutex.lock()?;
+        while self.isotp_tx_res_queue.try_recv().is_ok(){}
+        self.isotp_tx_queue.send(ChannelMessage::Close)?;
+        // Wait for channels response
+        self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 
-    fn set_ids(&mut self, send: u32, recv: u32) -> crate::channel::ChannelResult<()> {
-        todo!()
+    fn set_ids(&mut self, send: u32, recv: u32) -> ChannelResult<()> {
+        log::debug!("ISO-TP SetIDS called");
+        let _guard = self.isotp_mutex.lock()?;
+        while self.isotp_tx_res_queue.try_recv().is_ok(){}
+        self.isotp_tx_queue.send(ChannelMessage::SetFilter(send, recv))?;
+        // Wait for channels response
+        self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(100))?
     }
 
-    fn read_bytes(&mut self, timeout_ms: u32) -> crate::channel::ChannelResult<Vec<u8>> {
+    fn read_bytes(&mut self, timeout_ms: u32) -> ChannelResult<Vec<u8>> {
+        log::debug!("ISO-TP ReadBytes called");
         let timeout = std::cmp::max(1, timeout_ms);
         let instant = Instant::now();
         while instant.elapsed().as_millis() <= timeout as u128 {
@@ -194,28 +576,35 @@ impl PayloadChannel for PtCombiChannel {
         Err(ChannelError::BufferEmpty)
     }
 
-    fn write_bytes(&mut self, addr: u32, buffer: &[u8], _timeout_ms: u32) -> crate::channel::ChannelResult<()> {
+    fn write_bytes(&mut self, addr: u32, buffer: &[u8], timeout_ms: u32) -> ChannelResult<()> {
+        log::debug!("ISO-TP WriteBytes called");
+        let _guard = self.isotp_mutex.lock()?;
+        while self.isotp_tx_res_queue.try_recv().is_ok(){}
         self.isotp_tx_queue.send(ChannelMessage::SendData((addr, buffer.to_vec())))?;
+        if timeout_ms == 0 {
+            Ok(())
+        } else {
+            // Wait for channels response
+            self.isotp_tx_res_queue.recv_timeout(Duration::from_millis(timeout_ms as u64))?
+        }
+    }
+
+    fn clear_rx_buffer(&mut self) -> ChannelResult<()> {
+        log::debug!("ISO-TP ClearRxBuffer called");
+        while self.isotp_rx_queue.try_recv().is_ok(){}
         Ok(())
     }
 
-    fn clear_rx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
-        while self.isotp_rx_queue.recv().is_ok(){}
-        Ok(())
-    }
-
-    fn clear_tx_buffer(&mut self) -> crate::channel::ChannelResult<()> {
+    fn clear_tx_buffer(&mut self) -> ChannelResult<()> {
+        log::debug!("ISO-TP ClearTxBuffer called");
         Ok(self.isotp_tx_queue.send(ChannelMessage::ClearTx)?)
     }
 }
 
 impl Drop for PtCombiChannel {
     fn drop(&mut self) {
-        self.channel.close();
-        {
-            let mut this = self.dev.lock().unwrap();
-            this.can_channel = false;
-            this.isotp_channel = false;
-        }
+        log::debug!("Drop called");
+        self.running.store(false, Ordering::Relaxed);
+        self.handle.take().map(|x| x.join());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,14 @@ pub trait DiagnosticServer<CommandType> {
     /// Sets the minimum interval in milliseconds
     /// between a command failure and an attempted repeat transmission
     fn set_repeat_interval_count(&mut self, interval_ms: u32);
+
+    /// Sets read and write timeouts
+    fn set_rw_timeout(&mut self, read_timeout_ms: u32, write_timeout_ms: u32);
+
+    /// Get command response read timeout
+    fn get_read_timeout(&self) -> u32;
+    /// Gets command write timeout
+    fn get_write_timeout(&self) -> u32;
 }
 
 /// Basic diagnostic server settings

--- a/src/obd2/mod.rs
+++ b/src/obd2/mod.rs
@@ -488,6 +488,20 @@ impl DiagnosticServer<OBD2Command> for OBD2DiagnosticServer {
     fn is_server_running(&self) -> bool {
         self.server_running.load(Ordering::Relaxed)
     }
+
+    /// Sets read and write timeouts
+    fn set_rw_timeout(&mut self, _read_timeout_ms: u32, _write_timeout_ms: u32) {
+        // Does nothing on OBD
+    }
+
+    /// Get command response read timeout
+    fn get_read_timeout(&self) -> u32 {
+        10000
+    }
+    /// Gets command write timeout
+    fn get_write_timeout(&self) -> u32 {
+        10000
+    }
 }
 
 /// Returns the OBD2 error from a given error code

--- a/src/obd2/mod.rs
+++ b/src/obd2/mod.rs
@@ -1,11 +1,9 @@
 //! Module for OBD (ISO-9141)
 
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        mpsc, Arc,
-    },
-    time::Instant,
+use std::time::Instant;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc,
 };
 
 use crate::{

--- a/src/obd2/service01.rs
+++ b/src/obd2/service01.rs
@@ -113,7 +113,7 @@ pub mod service_09_test {
             IsoTPSettings {
                 block_size: 8,
                 st_min: 20,
-                extended_addressing: false,
+                extended_addresses: None,
                 pad_frame: true,
                 can_speed: 500_000,
                 can_use_ext_addr: false,

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -141,7 +141,7 @@ pub mod service_09_test {
             IsoTPSettings {
                 block_size: 8,
                 st_min: 20,
-                extended_addressing: false,
+                extended_addresses: None,
                 pad_frame: true,
                 can_speed: 500_000,
                 can_use_ext_addr: false,


### PR DESCRIPTION
This is a specific fix for Passthru devices.

This allows for a software based ISO-TP channel to be used, allowing for both CAN+ISOTP communication protocols to be used at the same time. 

This is because with the Passthru J2534 API, ISOTP and CAN are listed as conflicting channels, meaning both cannot be run at the same time