### PR TITLE
Upgrade to auto_uds v0.3, some minor renames

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Build and test FFI
+      run: |
+        cargo build --verbose --package ecu_diagnostics_ffi --no-default-features
+        cargo build --verbose --package ecu_diagnostics_ffi
+        cargo test --verbose --package ecu_diagnostics_ffi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ passthru = ["dep:libloading", "dep:shellexpand", "dep:winreg", "dep:serde_json",
 
 
 [dependencies]
-auto_uds = { version = "0.2", features = ["std"] }
+auto_uds = "0.3"
 j2534_rust = { version = "1.5.0", optional = true }
 serde_json = { version = "1.0.79", optional = true }
 libloading = { version = "0.7.3", optional = true }

--- a/src/uds/clear_diagnostic_information.rs
+++ b/src/uds/clear_diagnostic_information.rs
@@ -1,6 +1,6 @@
 //!  Provides methods to clear diagnostic trouble codes from the ECU
 
-use super::{UDSCommand, UdsDiagnosticServer};
+use super::{UdsCommand, UdsDiagnosticServer};
 use crate::{DiagServerResult, DiagnosticServer};
 
 impl UdsDiagnosticServer {
@@ -11,7 +11,7 @@ impl UdsDiagnosticServer {
     /// * dtc_mask - Mask of DTCs to clear. Only the lower 3 bytes are used (from 0x00000000 - 0x00FFFFFF)
     pub fn clear_diagnostic_information(&mut self, dtc_mask: u32) -> DiagServerResult<()> {
         self.execute_command_with_response(
-            UDSCommand::ClearDiagnosticInformation,
+            UdsCommand::ClearDiagnosticInformation,
             &[
                 (dtc_mask >> 16) as u8,
                 (dtc_mask >> 8) as u8,

--- a/src/uds/communication_control.rs
+++ b/src/uds/communication_control.rs
@@ -1,6 +1,6 @@
 //! Provides methods to control normal ECU communication
 
-use crate::uds::{UDSCommand, UdsDiagnosticServer};
+use crate::uds::{UdsCommand, UdsDiagnosticServer};
 use crate::DiagnosticServer;
 
 pub use auto_uds::{
@@ -26,7 +26,7 @@ impl UdsDiagnosticServer {
         let communication_type = encode_communication_type(communication_type, subnet);
 
         self.execute_command_with_response(
-            UDSCommand::CommunicationControl,
+            UdsCommand::CommunicationControl,
             &[level, communication_type],
         )
         .map(|_| ())

--- a/src/uds/diagnostic_session_control.rs
+++ b/src/uds/diagnostic_session_control.rs
@@ -1,16 +1,19 @@
 //!  Provides methods to manipulate the ECUs diagnostic session mode
 
+use super::{UdsCommand, UdsDiagnosticServer};
 use crate::{DiagServerResult, DiagnosticServer};
 
-use super::{UDSCommand, UdsDiagnosticServer};
-
+/// FIXME: This is deprecated, use UdsSessionType instead
+/// Note: `#[deprecated]` doesn't work here due to https://github.com/rust-lang/rust/issues/30827
 pub use auto_uds::UdsSessionType as UDSSessionType;
+
+pub use auto_uds::UdsSessionType;
 
 impl UdsDiagnosticServer {
     /// Requests the ECU to go into a specific diagnostic session mode
-    pub fn set_session_mode(&mut self, session_mode: UDSSessionType) -> DiagServerResult<()> {
+    pub fn set_session_mode(&mut self, session_mode: UdsSessionType) -> DiagServerResult<()> {
         self.execute_command_with_response(
-            UDSCommand::DiagnosticSessionControl,
+            UdsCommand::DiagnosticSessionControl,
             &[session_mode.into()],
         )
         .map(|_| ())

--- a/src/uds/ecu_reset.rs
+++ b/src/uds/ecu_reset.rs
@@ -1,7 +1,8 @@
 //!  Provides methods to reset the ECU in order to simulate power cycling and resetting memory regions
 
-use super::{lookup_uds_nrc, UDSCommand, UdsDiagnosticServer};
+use super::{lookup_uds_nrc, UdsDiagnosticServer};
 use crate::{DiagError, DiagServerResult, DiagnosticServer};
+use auto_uds::UdsCommand::*;
 
 pub use auto_uds::ResetType;
 
@@ -11,7 +12,7 @@ impl UdsDiagnosticServer {
     /// ## Parameters
     /// * server - The UDS Diagnostic server
     pub fn ecu_hard_reset(&mut self) -> DiagServerResult<()> {
-        self.execute_command_with_response(UDSCommand::ECUReset, &[ResetType::HardReset.into()])
+        self.execute_command_with_response(ResetEcu, &[ResetType::HardReset.into()])
             .map(|_| ())
     }
 
@@ -20,7 +21,7 @@ impl UdsDiagnosticServer {
     /// ## Parameters
     /// * server - The UDS Diagnostic server
     pub fn ecu_key_off_on_reset(&mut self) -> DiagServerResult<()> {
-        self.execute_command_with_response(UDSCommand::ECUReset, &[ResetType::KeyOffReset.into()])
+        self.execute_command_with_response(ResetEcu, &[ResetType::KeyOffReset.into()])
             .map(|_| ())
     }
 
@@ -29,7 +30,7 @@ impl UdsDiagnosticServer {
     /// ## Parameters
     /// * server - The UDS Diagnostic server
     pub fn ecu_soft_reset(&mut self) -> DiagServerResult<()> {
-        self.execute_command_with_response(UDSCommand::ECUReset, &[ResetType::SoftReset.into()])
+        self.execute_command_with_response(ResetEcu, &[ResetType::SoftReset.into()])
             .map(|_| ())
     }
 
@@ -42,7 +43,7 @@ impl UdsDiagnosticServer {
     /// If successful, this function will return the minimum time in seconds that the ECU will remain in the power-down sequence
     pub fn enable_rapid_power_shutdown(&mut self) -> DiagServerResult<u8> {
         let res = self.execute_command_with_response(
-            UDSCommand::ECUReset,
+            ResetEcu,
             &[ResetType::EnableRapidPowerShutDown.into()],
         )?;
         match res.get(2) {
@@ -60,10 +61,7 @@ impl UdsDiagnosticServer {
     /// ## Parameters
     /// * server - The UDS Diagnostic server
     pub fn disable_rapid_power_shutdown(&mut self) -> DiagServerResult<()> {
-        self.execute_command_with_response(
-            UDSCommand::ECUReset,
-            &[ResetType::DisableRapidPowerShutDown.into()],
-        )
-        .map(|_| ())
+        self.execute_command_with_response(ResetEcu, &[ResetType::DisableRapidPowerShutDown.into()])
+            .map(|_| ())
     }
 }

--- a/src/uds/read_dtc_information.rs
+++ b/src/uds/read_dtc_information.rs
@@ -5,7 +5,7 @@ use crate::{
     DiagError, DiagServerResult, DiagnosticServer,
 };
 
-use super::{UDSCommand, UdsDiagnosticServer};
+use super::{UdsCommand, UdsDiagnosticServer};
 
 pub use auto_uds::DtcSubFunction;
 
@@ -23,9 +23,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<(u8, DTCFormatType, u16)> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportNumberOfDTCByStatusMask as u8,
+                DtcSubFunction::ReportNumberOfDtcByStatusMask as u8,
                 status_mask,
             ],
         )?;
@@ -46,8 +46,8 @@ impl UdsDiagnosticServer {
     /// matching the provided status_mask
     pub fn get_dtcs_by_status_mask(&mut self, status_mask: u8) -> DiagServerResult<Vec<DTC>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportDTCByStatusMask as u8, status_mask],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportDtcByStatusMask as u8, status_mask],
         )?;
         if resp.len() < 7 {
             return Ok(vec![]); // No errors
@@ -93,9 +93,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<Vec<DTC>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportMirrorMemoryDTCByStatusMask as u8,
+                DtcSubFunction::ReportMirrorMemoryDtcByStatusMask as u8,
                 status_mask,
             ],
         )?;
@@ -148,9 +148,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<(u8, DTCFormatType, u16)> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportNumberOfMirrorMemoryDTCByStatusMask as u8,
+                DtcSubFunction::ReportNumberOfMirrorMemoryDtcByStatusMask as u8,
                 status_mask,
             ],
         )?;
@@ -179,9 +179,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<(u8, DTCFormatType, u16)> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportNumberOfEmissionsRelatedOBDDTCByStatusMask as u8,
+                DtcSubFunction::ReportNumberOfEmissionsRelatedObdDtcByStatusMask as u8,
                 status_mask,
             ],
         )?;
@@ -204,9 +204,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<Vec<DTC>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportEmissionsRelatedOBDDTCByStatusMask as u8,
+                DtcSubFunction::ReportEmissionsRelatedObdDtcByStatusMask as u8,
                 status_mask,
             ],
         )?;
@@ -253,9 +253,9 @@ impl UdsDiagnosticServer {
         snapshot_record_number: u8,
     ) -> DiagServerResult<u32> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportDTCSnapshotRecordByDTCNumber as u8,
+                DtcSubFunction::ReportDtcSnapshotRecordByDtcNumber as u8,
                 (dtc_mask_record >> 16) as u8,
                 (dtc_mask_record >> 8) as u8,
                 dtc_mask_record as u8,
@@ -271,8 +271,8 @@ impl UdsDiagnosticServer {
     /// Returns all DTC snapshot identifications (DTC number(s) and DTCSnapshot record number(s))
     pub fn get_dtc_snapshot_identification(&mut self) -> DiagServerResult<u32> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportDTCSnapshotIdentifier as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportDtcSnapshotIdentifier as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
             "ECU Response was: {:02X?}",
@@ -286,9 +286,9 @@ impl UdsDiagnosticServer {
         snapshot_record_number: u8,
     ) -> DiagServerResult<u32> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportDTCSnapshotRecordByRecordNumber as u8,
+                DtcSubFunction::ReportDtcSnapshotRecordByRecordNumber as u8,
                 snapshot_record_number,
             ],
         )?;
@@ -309,9 +309,9 @@ impl UdsDiagnosticServer {
         extended_data_record_number: u8,
     ) -> DiagServerResult<Vec<u8>> {
         self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportDTCExtendedDataRecordByDTCNumber as u8,
+                DtcSubFunction::ReportDtcExtendedDataRecordByDtcNumber as u8,
                 (dtc >> 16) as u8, // High byte
                 (dtc >> 8) as u8,  // Mid byte
                 dtc as u8,         // Low byte
@@ -331,9 +331,9 @@ impl UdsDiagnosticServer {
         extended_data_record_number: u8,
     ) -> DiagServerResult<Vec<u8>> {
         self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportMirrorMemoryDTCExtendedDataRecordByDTCNumber as u8,
+                DtcSubFunction::ReportMirrorMemoryDtcExtendedDataRecordByDtcNumber as u8,
                 (dtc >> 16) as u8, // High byte
                 (dtc >> 8) as u8,  // Mid byte
                 dtc as u8,         // Low byte
@@ -349,9 +349,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<u32> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportNumberOfDTCBySeverityMaskRecord as u8,
+                DtcSubFunction::ReportNumberOfDtcBySeverityMaskRecord as u8,
                 severity_mask,
                 status_mask,
             ],
@@ -369,9 +369,9 @@ impl UdsDiagnosticServer {
         status_mask: u8,
     ) -> DiagServerResult<Vec<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportDTCBySeverityMaskRecord as u8,
+                DtcSubFunction::ReportDtcBySeverityMaskRecord as u8,
                 severity_mask,
                 status_mask,
             ],
@@ -385,9 +385,9 @@ impl UdsDiagnosticServer {
     /// Returns the severity status of a provided DTC
     pub fn get_severity_information_of_dtc(&mut self, dtc: u32) -> DiagServerResult<u32> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
+            UdsCommand::ReadDtcInformation,
             &[
-                DtcSubFunction::ReportSeverityInformationOfDTC as u8,
+                DtcSubFunction::ReportSeverityInformationOfDtc as u8,
                 (dtc >> 16) as u8,
                 (dtc >> 8) as u8,
                 dtc as u8,
@@ -402,8 +402,8 @@ impl UdsDiagnosticServer {
     /// Returns a list of all DTCs that the ECU can return
     pub fn get_supported_dtc(&mut self) -> DiagServerResult<Vec<DTC>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportSupportedDTC as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportSupportedDtc as u8],
         )?;
         if resp.len() < 7 {
             return Ok(vec![]); // No errors
@@ -444,8 +444,8 @@ impl UdsDiagnosticServer {
     /// Returns the first failed DTC to be detected since the last DTC clear operation
     pub fn get_first_test_failed_dtc(&mut self) -> DiagServerResult<Option<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportFirstTestFailedDTC as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportFirstTestFailedDtc as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
             "ECU Response was: {:02X?}",
@@ -456,8 +456,8 @@ impl UdsDiagnosticServer {
     /// Returns the first confirmed DTC to be detected since the last DTC clear operation
     pub fn get_first_confirmed_dtc(&mut self) -> DiagServerResult<Option<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportFirstConfirmedDTC as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportFirstConfirmedDtc as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
             "ECU Response was: {:02X?}",
@@ -468,11 +468,11 @@ impl UdsDiagnosticServer {
     /// Returns the most recent DTC to be detected since the last DTC clear operation
     pub fn get_most_recent_test_failed_dtc(&mut self) -> DiagServerResult<Option<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportMostRecentTestFailedDTC as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportMostRecentTestFailedDtc as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
-            "ReportMostRecentTestFailedDTC ECU Response was: {:02X?}",
+            "ReportMostRecentTestFailedDtc ECU Response was: {:02X?}",
             resp
         )))
     }
@@ -480,11 +480,11 @@ impl UdsDiagnosticServer {
     /// Returns the most recent DTC to be detected since the last DTC clear operation
     pub fn get_most_recent_confirmed_dtc(&mut self) -> DiagServerResult<Option<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportMostRecentConfirmedDTC as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportMostRecentConfirmedDtc as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
-            "ReportMostRecentConfirmedDTC ECU Response was: {:02X?}",
+            "ReportMostRecentConfirmedDtc ECU Response was: {:02X?}",
             resp
         )))
     }
@@ -498,8 +498,8 @@ impl UdsDiagnosticServer {
     /// 2. (u8) - Fault detection counter
     pub fn get_dtc_fault_detection_counter(&mut self) -> DiagServerResult<Vec<(u32, u8)>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportDTCFaultDetectionCounter as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportDtcFaultDetectionCounter as u8],
         )?;
         if resp.len() < 6 {
             return Ok(vec![]); // No errors
@@ -523,11 +523,11 @@ impl UdsDiagnosticServer {
     /// Returns a list of DTCs that have a permanent status
     pub fn get_dtc_with_permanent_status(&mut self) -> DiagServerResult<Vec<DTC>> {
         let resp = self.execute_command_with_response(
-            UDSCommand::ReadDTCInformation,
-            &[DtcSubFunction::ReportDTCWithPermanentStatus as u8],
+            UdsCommand::ReadDtcInformation,
+            &[DtcSubFunction::ReportDtcWithPermanentStatus as u8],
         )?;
         Err(DiagError::NotImplemented(format!(
-            "ReportDTCWithPermanentStatus ECU Response was: {:02X?}",
+            "ReportDtcWithPermanentStatus ECU Response was: {:02X?}",
             resp
         )))
     }

--- a/src/uds/scaling_data.rs
+++ b/src/uds/scaling_data.rs
@@ -1,5 +1,14 @@
 ///! Functions and data for ReadScalingDataById UDS Service
-pub use auto_uds::{ScalingByteExtension, ScalingByteHigh};
+
+/// FIXME: Use ScalingExtension instead
+/// Note: `#[deprecated]` doesn't work here due to https://github.com/rust-lang/rust/issues/30827
+pub use auto_uds::ScalingExtension as ScalingByteExtension;
+
+/// FIXME: Use ScalingType instead
+/// Note: `#[deprecated]` doesn't work here due to https://github.com/rust-lang/rust/issues/30827
+pub use auto_uds::ScalingType as ScalingByteHigh;
+
+pub use auto_uds::{ScalingExtension, ScalingType};
 
 /// Represents Scaling data structure returned from ECU
 #[derive(Debug, Clone)]
@@ -9,7 +18,7 @@ pub struct ScalingData {
     c1: f32,
     c2: f32,
     mapping_byte: u8,
-    byte_ext: Vec<ScalingByteExtension>,
+    byte_ext: Vec<ScalingExtension>,
 }
 
 impl ScalingData {
@@ -20,7 +29,7 @@ impl ScalingData {
         c1: i32,
         c2: i32,
         mapping_byte: u8,
-        byte_ext: &[ScalingByteExtension],
+        byte_ext: &[ScalingExtension],
     ) -> Self {
         Self {
             x: x as f32,
@@ -34,7 +43,7 @@ impl ScalingData {
 
     /// Returns the list of scaling data presentation of the scaling data.
     /// Note that there can be more than one! (EG: Having a prefix and postfix scaling byte)
-    pub fn get_scaling_byte(&self) -> &[ScalingByteExtension] {
+    pub fn get_scaling_byte(&self) -> &[ScalingExtension] {
         &self.byte_ext
     }
 

--- a/src/uds/security_access.rs
+++ b/src/uds/security_access.rs
@@ -3,7 +3,7 @@
 //!
 //! Currently, only default seed/key (0x01/0x02) are supported
 
-use super::{UDSCommand, UdsDiagnosticServer};
+use super::{UdsCommand, UdsDiagnosticServer};
 use crate::{DiagServerResult, DiagnosticServer};
 
 pub use auto_uds::SecurityOperation;
@@ -20,7 +20,7 @@ impl UdsDiagnosticServer {
     /// Returns the security key's seed
     pub fn request_seed(&mut self) -> DiagServerResult<Vec<u8>> {
         let mut resp = self.execute_command_with_response(
-            UDSCommand::SecurityAccess,
+            UdsCommand::SecurityAccess,
             &[SecurityOperation::RequestSeed.into()],
         )?;
         resp.drain(0..2); // Remove SID and PID, so just seed value left
@@ -38,7 +38,7 @@ impl UdsDiagnosticServer {
         let mut payload = Vec::with_capacity(key.len() + 1);
         payload.push(SecurityOperation::SendKey.into());
         payload.extend_from_slice(key);
-        self.execute_command_with_response(UDSCommand::SecurityAccess, &payload)
+        self.execute_command_with_response(UdsCommand::SecurityAccess, &payload)
             .map(|_| ())
     }
 }


### PR DESCRIPTION
Mark some re-exported types as deprecated, but sadly deprecated attribute does not (yet) work in rustc.  I will remove the aliasing in a separate PR for ease of review.