### PR TITLE
Allow for Diag Session to be safe between threads and fix UDS Session control function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecu_diagnostics"
-version = "0.91.0"
+version = "0.91.1"
 authors = ["Ashcon Mohseninia <ashconm@outlook.com>"]
 edition = "2021"
 description = "A rust crate for ECU diagnostic servers and communication APIs"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Unlike OBD2, KWP2000 allows for much more complex operations, which could potent
 
  The specification implemented in this crate is the second edition, dated 01-12-2006.
 
-# NEW (As off version 0.99! UNIFIED DIAGNOSTIC SERVER!)
+# NEW (As off version 0.91! UNIFIED DIAGNOSTIC SERVER!)
 The individual diagnostic servers are now merged into 1 diagnostic server that can handle all the different protocols
 (Diagnostic protocol is specified at the servers creation). This dramatically reduces the crates bloat (Less copy/paste code),
 and the refactoring has also introduced some new features:

--- a/src/obd2/data_pids.rs
+++ b/src/obd2/data_pids.rs
@@ -17,7 +17,7 @@ pub struct DataPidWrapper(DataPidByte);
 impl DataPidWrapper {
     fn request_ecu(
         &self,
-        server: &mut DynamicDiagSession,
+        server: &DynamicDiagSession,
         ff: Option<u16>,
         min_length: usize,
     ) -> DiagServerResult<Vec<u8>> {
@@ -36,7 +36,7 @@ impl DataPidWrapper {
     /// For value = A*100/255
     fn get_percentage_1_byte(
         &self,
-        server: &mut DynamicDiagSession,
+        server: &DynamicDiagSession,
         ff: Option<u16>,
         name: &str,
     ) -> DiagServerResult<Vec<ObdValue>> {
@@ -50,7 +50,7 @@ impl DataPidWrapper {
     #[allow(clippy::excessive_precision)]
     pub(crate) fn get_value(
         &self,
-        server: &mut DynamicDiagSession,
+        server: &DynamicDiagSession,
         ff: Option<u16>,
     ) -> DiagServerResult<Vec<ObdValue>> {
         use automotive_diag::obd2::DataPid::*;

--- a/src/obd2/service01.rs
+++ b/src/obd2/service01.rs
@@ -9,7 +9,7 @@ use automotive_diag::obd2::{DataPidByte, Obd2Command};
 #[derive(Debug)]
 /// Service 01 wrapper for OBD
 pub struct Service01<'a> {
-    server: &'a mut DynamicDiagSession,
+    server: &'a DynamicDiagSession,
     support_list: Vec<bool>,
 }
 
@@ -18,7 +18,7 @@ impl DynamicDiagSession {
     /// on init for supported PIDs.
     /// NOTE: Unlike other functions, if this function encounters a ECU communication
     /// error, it will still return OK.
-    pub fn obd_init_service_01(&mut self) -> DiagServerResult<Service01> {
+    pub fn obd_init_service_01(&self) -> DiagServerResult<Service01> {
         // Query supported pids
         let mut total_support_list = Vec::new();
         for i in (0..0xFF).step_by(0x20) {
@@ -62,8 +62,8 @@ impl<'a> Service01<'a> {
     }
 
     /// Query's a data PID from Service 01
-    pub fn query_pid(&mut self, pid: DataPidWrapper) -> DiagServerResult<Vec<ObdValue>> {
-        pid.get_value(self.server, None)
+    pub fn query_pid(&self, pid: DataPidWrapper) -> DiagServerResult<Vec<ObdValue>> {
+        pid.get_value(&self.server, None)
     }
 }
 

--- a/src/obd2/service09.rs
+++ b/src/obd2/service09.rs
@@ -9,14 +9,14 @@ use automotive_diag::ByteWrapper::{Extended, Standard};
 #[derive(Debug)]
 /// Service 09 wrapper for OBD
 pub struct Service09<'a> {
-    server: &'a mut DynamicDiagSession,
+    server: &'a DynamicDiagSession,
     support_list: Vec<bool>,
 }
 
 impl DynamicDiagSession {
     /// Initializes the service 09 wrapper. Automatically query's the ECU
     /// on init for supported PIDs
-    pub fn obd_init_service_09(&mut self) -> DiagServerResult<Service09> {
+    pub fn obd_init_service_09(&self) -> DiagServerResult<Service09> {
         // Query supported pids
         let pid_support_list = self.send_command_with_response(Obd2Command::Service09, &[0x00])?;
         Ok(Service09 {

--- a/src/uds/diagnostic_session_control.rs
+++ b/src/uds/diagnostic_session_control.rs
@@ -2,12 +2,11 @@
 
 use crate::{dynamic_diag::DynamicDiagSession, DiagServerResult};
 
-use automotive_diag::uds::UdsCommand;
-pub use automotive_diag::uds::UdsSessionType as UDSSessionType;
+use automotive_diag::uds::{UdsCommand, UdsSessionTypeByte};
 
 impl DynamicDiagSession {
     /// Requests the ECU to go into a specific diagnostic session mode
-    pub fn uds_set_session_mode(&self, session_mode: UDSSessionType) -> DiagServerResult<()> {
+    pub fn uds_set_session_mode(&self, session_mode: UdsSessionTypeByte) -> DiagServerResult<()> {
         self.send_command_with_response(
             UdsCommand::DiagnosticSessionControl,
             &[session_mode.into()],

--- a/src/uds/mod.rs
+++ b/src/uds/mod.rs
@@ -104,7 +104,7 @@ impl Default for UDSProtocol {
 impl DiagProtocol<ByteWrapper<UdsError>> for UDSProtocol {
     fn get_basic_session_mode(&self) -> Option<DiagSessionMode> {
         self.session_modes
-            .get(&UDSSessionType::Default.into())
+            .get(&UdsSessionType::Default.into())
             .cloned()
     }
 


### PR DESCRIPTION
1. Sender for Server Tx is now wrapped in a Mutex, making this thread safe (To prevent unordered parallel access).
2. `uds::uds_set_session_mode` now accepts `UdsSessionTypeByte` rather than `UdsSessionType`