### PR TITLE
Fix build with default settings

### DIFF
--- a/src/dynamic_diag.rs
+++ b/src/dynamic_diag.rs
@@ -322,7 +322,7 @@ impl DynamicDiagSession {
                         let mut tx_addr = basic_opts.send_id;
                         match protocol.process_req_payload(&req.payload) {
                             DiagAction::SetSessionMode(mode) => {
-                                let mut needs_response = true;
+                                let needs_response = true;
                                 let mut ext_id = None;
                                 let res = send_recv_ecu_req::<P, NRC, L>(
                                     tx_addr,

--- a/src/kwp2000/mod.rs
+++ b/src/kwp2000/mod.rs
@@ -33,19 +33,11 @@ mod security_access;
 mod start_diagnostic_session;
 
 pub use clear_diagnostic_information::*;
-pub use ecu_reset::*;
-pub use error::*;
 pub use ioctl_mgr::*;
-pub use message_transmission::*;
-pub use read_data_by_identifier::*;
 pub use read_data_by_local_id::*;
 pub use read_dtc_by_status::*;
 pub use read_ecu_identification::*;
-pub use read_memory_by_address::*;
-pub use read_status_of_dtc::*;
 pub use routine::*;
-pub use security_access::*;
-pub use start_diagnostic_session::*;
 
 #[derive(Debug, Clone)]
 /// KWP2000 diagnostic protocol

--- a/src/uds/mod.rs
+++ b/src/uds/mod.rs
@@ -15,16 +15,10 @@ mod read_dtc_information;
 mod scaling_data;
 mod security_access;
 
-pub use access_timing_parameter::*;
 pub use automotive_diag::uds::*;
 use automotive_diag::ByteWrapper;
-pub use clear_diagnostic_information::*;
 pub use communication_control::*;
-pub use diagnostic_session_control::*;
-pub use ecu_reset::*;
-pub use read_dtc_information::*;
 pub use scaling_data::*;
-pub use security_access::*;
 
 pub use automotive_diag::uds::UdsError;
 

--- a/src/uds/scaling_data.rs
+++ b/src/uds/scaling_data.rs
@@ -1,14 +1,6 @@
 ///! Functions and data for ReadScalingDataById UDS Service
 
-/// FIXME: Use ScalingExtension instead
-/// Note: `#[deprecated]` doesn't work here due to https://github.com/rust-lang/rust/issues/30827
-pub use automotive_diag::uds::ScalingExtension as ScalingByteExtension;
-
-/// FIXME: Use ScalingType instead
-/// Note: `#[deprecated]` doesn't work here due to https://github.com/rust-lang/rust/issues/30827
-pub use automotive_diag::uds::ScalingType as ScalingByteHigh;
-
-pub use automotive_diag::uds::{ScalingExtension, ScalingType};
+pub use automotive_diag::uds::ScalingExtension;
 
 /// Represents Scaling data structure returned from ECU
 #[derive(Debug, Clone)]


### PR DESCRIPTION
These unused imports produce errors with the default latest Rust. Fix them to make it build out of the box.