### PR TITLE
Fix the test suite so it compiles

### DIFF
--- a/src/dtc.rs
+++ b/src/dtc.rs
@@ -110,11 +110,11 @@ impl DTC {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use super::DTC;
 
     #[test]
-    pub fn test_dtc_parse_raw() {
+    fn test_dtc_parse_raw() {
         let iso15031_6_dtc = DTC {
             format: super::DTCFormatType::Iso15031_6,
             raw: 8276,

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -6,7 +6,7 @@ mod dpdu;
 pub mod vwtp;
 
 #[cfg(test)]
-pub mod simulation;
+mod simulation;
 
 #[cfg(feature = "passthru")]
 pub mod passthru; // Not finished at all yet, hide from the crate

--- a/src/obd2/service01.rs
+++ b/src/obd2/service01.rs
@@ -68,7 +68,7 @@ impl<'a> Service01<'a> {
 }
 
 #[cfg(test)]
-pub mod service_09_test {
+mod service_09_test {
     use crate::obd2::units::{ObdUnitType, ObdValue};
     use crate::DiagServerResult;
 


### PR DESCRIPTION
`cargo test` currently fails to compile the library, so the test suite does not run at all.

The crate sets `#![deny(missing_docs)]` in `lib.rs`, and three test-only items are declared `pub` without doc comments:

- `src/dtc.rs` — `pub mod test` and `pub fn test_dtc_parse_raw`
- `src/obd2/service01.rs` — `pub mod service_09_test`
- `src/hardware/mod.rs` — `pub mod simulation`

Under `cfg(test)` those items become public, `missing_docs` fires, and the `lib test` target fails with three errors before any test runs:

```
error: missing documentation for a module
error: missing documentation for a function
error: missing documentation for a module
error: could not compile `ecu_diagnostics` (lib test) due to 3 previous errors
```

This means the `Run tests` step in `.github/workflows/rust.yml` has been failing, and the existing `test_dtc_parse_raw` test has never executed. The most recent runs on `main` are all red, going back to at least April 2026.

## The change

Test scaffolding is not public API, so this drops the `pub` rather than adding doc comments for it. All three modules are already behind `#[cfg(test)]`, so they were never reachable from downstream crates and this is not a breaking change.

## Verification

```
$ cargo test --lib
running 1 test
test dtc::test::test_dtc_parse_raw ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Four lines changed across three files, no behaviour change outside `cfg(test)`.

One thing left alone deliberately: on non-Linux hosts `cargo test` still fails to build `examples/kwp.rs`, which refers to `hardware::socketcan` unconditionally although the module is gated on `target_os = "linux"`. That does not affect CI, which runs on Ubuntu, so it seemed better suited to a separate PR than widening this one.
