### PR TITLE
Fix the pcan-usb feature, and build every feature in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,12 +10,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # `slcan` is a default feature, it pulls in `serialport`, and `serialport`
+  # needs `libudev` on Linux, which the runner image does not carry. So
+  # `cargo build` on the default feature set has been failing here on every
+  # push, and the missing package is the whole reason. Installing it is what
+  # makes the rest of this file mean anything.
   build:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v7
+    - name: Install libudev
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
     - name: Build No Features
       run: cargo build --verbose --no-default-features
     - name: Build
@@ -49,6 +56,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+    - name: Install libudev
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
     - name: Build
       run: cargo build --verbose ${{ matrix.args }}
     - name: Test
@@ -68,6 +78,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+    - name: Install libudev
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
     - run: rustup component add clippy
     - name: Clippy
       run: cargo clippy --all-targets --all-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Build No Features
       run: cargo build --verbose --no-default-features
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,50 @@ jobs:
       run: cargo test --verbose
     - name: Build examples
       run: cargo build --examples --verbose
+
+  # The job above builds and tests the default feature set, so a feature
+  # outside it could stop compiling, and tests behind it could stop running,
+  # without anything noticing. Build and test each one. No entry for the empty
+  # feature set: the job above already builds that.
+  features:
+
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: "passthru", os: ubuntu-latest, args: "--no-default-features --features passthru" }
+          - { name: "socketcan", os: ubuntu-latest, args: "--no-default-features --features socketcan" }
+          - { name: "slcan", os: ubuntu-latest, args: "--no-default-features --features slcan" }
+          - { name: "serde", os: ubuntu-latest, args: "--no-default-features --features serde" }
+          - { name: "pcan-usb", os: ubuntu-latest, args: "--no-default-features --features pcan-usb" }
+          # pcan-usb is a Windows driver, so build it on its real target too
+          - { name: "pcan-usb (windows)", os: windows-latest, args: "--no-default-features --features pcan-usb" }
+          - { name: "all features", os: ubuntu-latest, args: "--all-features" }
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build
+      run: cargo build --verbose ${{ matrix.args }}
+    - name: Test
+      run: cargo test --lib --verbose ${{ matrix.args }}
+
+  # `lib.rs` denies a list of lints, one of which is a clippy lint, but no job
+  # ran clippy, so `cargo clippy` exited 101 on a clean checkout. This job runs
+  # it, so the deny list is checked on every change.
+  #
+  # Deliberately not `-- -D warnings`. The crate carries dozens of pre-existing
+  # warnings, and failing the build on them would make this job a demand to
+  # clean all of them rather than a guard on the deny list the crate already
+  # chose. This fails on exactly what the crate says is not allowed.
+  clippy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - run: rustup component add clippy
+    - name: Clippy
+      run: cargo clippy --all-targets --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ passthru = [
     "dep:j2534_rust",
 ]
 slcan = ["dep:serialport"]
-pcan-usb = ["dep:libloading", "dep:winapi", "dep:enum-repr"]
+pcan-usb = ["dep:libloading", "dep:enum-repr"]
 serde = ["dep:serde", "bitflags/serde", "automotive_diag/serde"]
 
 [dependencies]
@@ -40,7 +40,6 @@ automotive_diag = "0.1.28"
 j2534_rust = { version = "1.5.0", optional = true }
 serde_json = { version = "1.0.150", optional = true }
 libloading = { version = "0.9.0", optional = true }
-winapi = { version = "0.3.9", optional = true }
 enum-repr = { version = "0.2.6", optional = true }
 log = "0.4.32"
 strum = "0.28.0"

--- a/src/dtc.rs
+++ b/src/dtc.rs
@@ -110,11 +110,11 @@ impl DTC {
 }
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use super::DTC;
 
     #[test]
-    pub fn test_dtc_parse_raw() {
+    fn test_dtc_parse_raw() {
         let iso15031_6_dtc = DTC {
             format: super::DTCFormatType::Iso15031_6,
             raw: 8276,

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -6,7 +6,7 @@ mod dpdu;
 pub mod vwtp;
 
 #[cfg(test)]
-pub mod simulation;
+mod simulation;
 
 #[cfg(feature = "passthru")]
 pub mod passthru; // Not finished at all yet, hide from the crate

--- a/src/hardware/pcan_usb/lib_funcs.rs
+++ b/src/hardware/pcan_usb/lib_funcs.rs
@@ -1,6 +1,5 @@
 use libloading::Library;
-use winapi::shared::minwindef::{WORD, DWORD};
-use winapi::um::winnt::LPSTR;
+use super::{WORD, DWORD, LPSTR};
 use std::ffi::c_void;
 use std::mem::size_of;
 use std::path::Path;
@@ -141,6 +140,24 @@ impl fmt::Debug for PCanDrv {
 
 impl PCanDrv {
     pub fn load_lib() -> HardwareResult<PCanDrv> {
+        // The driver is only distributed as a Windows DLL, and the paths below
+        // are Windows-only. The feature still compiles everywhere so that
+        // docs.rs can document it, so reject other targets with a message that
+        // says why, rather than letting `Library::new` report a missing file.
+        if !cfg!(windows) {
+            return Err(HardwareError::APIError {
+                // 99 is what this crate already reports for a driver that could
+                // not be loaded: see the From<libloading::Error> impl in
+                // hardware/mod.rs. It must not be 0, which the PCAN API uses for
+                // success and check_pcan_func_result maps to Ok.
+                code: 99,
+                desc: "The pcan-usb feature requires Windows, because PCAN-Basic \
+                       is only distributed as a Windows DLL. On Linux, use a \
+                       PCAN-USB adapter via the native SocketCAN driver instead."
+                    .into(),
+            });
+        }
+
         let path: &'static str = if cfg!(target_pointer_width="32") {
             match Path::new("C:\\Program Files (x86)\\").exists() {
                 true => "C:\\Windows\\SysWOW64\\PCANBasic.dll", // 64bit
@@ -275,5 +292,35 @@ impl PCanDrv {
         unsafe { (self.write_fn)(handle as u16, &mut can_msg) }
         ).map_err(|e| HardwareError::from(e))?;
         Ok(())
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::PCanDrv;
+    use crate::hardware::HardwareError;
+
+    /// The PCAN-Basic driver ships as a Windows DLL. The feature still compiles
+    /// on other targets so docs.rs can document it, so loading has to fail with
+    /// a message naming the real reason.
+    #[test]
+    fn load_lib_reports_unsupported_platform() {
+        let err = PCanDrv::load_lib().expect_err("PCAN-Basic cannot load off Windows");
+
+        let HardwareError::APIError { desc, .. } = err else {
+            panic!("expected an APIError naming the platform, got {err:?}");
+        };
+        assert!(
+            desc.contains("Windows"),
+            "error should say the feature needs Windows, got: {desc}"
+        );
+        assert!(
+            !desc.contains(".dll"),
+            "error should not surface a DLL path on a non-Windows host, got: {desc}"
+        );
+        assert!(
+            desc.contains("DLL"),
+            "error should give the reason, not just the verdict, got: {desc}"
+        );
     }
 }

--- a/src/hardware/pcan_usb/mod.rs
+++ b/src/hardware/pcan_usb/mod.rs
@@ -13,6 +13,22 @@ use self::{lib_funcs::PCanDrv, pcan_types::{PcanUSB, PCANBaud}};
 
 use super::{HardwareInfo, HardwareScanner, Hardware, HardwareError, HardwareResult};
 
+// Win32 type aliases used by the PCAN-Basic ABI. Their widths are fixed by that
+// ABI, so they are spelled out here rather than pulled from a platform crate.
+// Note none of these may be replaced with the matching `std::ffi` alias: those
+// track the *host* C ABI, which differs. `c_ulong` is 64 bits on unix, and
+// `c_char` is unsigned on aarch64/arm linux, whereas Win32 `CHAR` is always
+// signed.
+
+/// Win32 `WORD`.
+pub (crate) type WORD = u16;
+
+/// Win32 `DWORD`.
+pub (crate) type DWORD = u32;
+
+/// Win32 `LPSTR`.
+pub (crate) type LPSTR = *mut i8;
+
 #[derive(Debug, Clone)]
 /// Can Mode
 enum CanMode {

--- a/src/hardware/pcan_usb/pcan_types.rs
+++ b/src/hardware/pcan_usb/pcan_types.rs
@@ -1,9 +1,10 @@
 
 use enum_repr::EnumRepr;
 use thiserror::Error;
-use winapi::shared::minwindef::{DWORD, WORD};
 
 use crate::{channel::ChannelError, hardware::HardwareError};
+
+use super::{DWORD, WORD};
 
 
 const MAX_LENGTH_HARDWARE_NAME: usize = 33;

--- a/src/hardware/vwtp.rs
+++ b/src/hardware/vwtp.rs
@@ -463,7 +463,7 @@ impl<T: VwApplicationProtocol> PayloadChannel for VwTransport2Channel<T> {
                     let bs = data[1];
                     let ack_timeout = decode_timing_byte(data[2]);
                     let st_min = decode_timing_byte(data[4]);
-                    log::debug!("ECU configuration reply: BS: {}, Ack timeout: {:?}, ST_MIN: {:?}", bs, ack_timeout, st_min);
+                    log::debug!("ECU configuration reply: BS: {bs}, Ack timeout: {ack_timeout:?}, ST_MIN: {st_min:?}");
                     self.start_background_thread(bs, ack_timeout, st_min, self.settings);
                     Ok(())
                 } else {

--- a/src/obd2/service01.rs
+++ b/src/obd2/service01.rs
@@ -68,7 +68,7 @@ impl<'a> Service01<'a> {
 }
 
 #[cfg(test)]
-pub mod service_09_test {
+mod service_09_test {
     use crate::obd2::units::{ObdUnitType, ObdValue};
     use crate::DiagServerResult;
 


### PR DESCRIPTION
`cargo build --all-features` does not build on this crate, and neither does
`cargo build --features pcan-usb`. `winapi` 0.3's type aliases are gated to
Windows targets, so `WORD`, `DWORD` and `LPSTR` fail to resolve anywhere else.
That matters beyond a local build: docs.rs is configured with
`all-features = true` across three targets, one of them `x86_64-apple-darwin`.

Three commits:

**`fix(pcan-usb): make the feature compile by dropping winapi`**

Only three Win32 aliases were used, and their widths are fixed by the
PCAN-Basic ABI rather than by the host, so they are defined locally and the
dependency is dropped. None of the three can be replaced with the matching
`std::ffi` alias, because those track the *host* C ABI: `c_ulong` is 64 bits on
unix, and `c_char` is unsigned on aarch64 linux, whereas Win32 `CHAR` is always
signed.

Loading the driver off Windows now returns an error saying the feature needs
Windows and why, rather than an opaque missing-file error out of
`Library::new`.

**`ci: update actions/checkout to v7`**

v2 runs on a Node runtime GitHub has retired, so every run logs a deprecation
warning.

**`ci: build and test every feature, not just the default set`**

The existing job covers the default feature set, so a feature outside it can
stop compiling, and tests behind it can stop running, without anything
noticing. Each feature now gets a build and a test, and `pcan-usb` is built on
Windows too, since that is its real target.

It also adds a clippy job. `lib.rs` denies a list of lints, one of them a
clippy lint, but no job ran clippy, so `cargo clippy` exited 101 on a clean
checkout on a violation in `vwtp.rs` the deny list already forbade. That
violation is fixed here so the new job starts green. The job deliberately does
not pass `-D warnings`: the crate carries dozens of pre-existing warnings, and
failing on those would make this a demand to clean all of them rather than a
guard on the standard the crate already set for itself.

---

Stacked on #39. Those four lines are what makes `cargo test --lib` compile, so
the matrix jobs need them; the diff here drops to its own three commits once
#39 merges. Happy to reorder or split if you would rather take these
separately.

---

**Added after opening this PR.** The Rust workflow has been failing on every push
to `main` (0.107.0 through 0.107.5), and the cause turns out to be the runner
rather than the code: `slcan` is a default feature, it pulls in `serialport`,
and `serialport` needs `libudev`, which the `ubuntu-latest` image does not carry.
The build log ends at

```
The system library `libudev` required by crate `libudev-sys` was not found.
```

so `cargo build` on the default feature set cannot get as far as compiling this
crate. A fourth commit installs it on the Linux jobs. Without it the new matrix
would have gone red on `slcan`, on `all features` and on clippy for that same
reason, and the red would have said nothing about the crate.
